### PR TITLE
Issue #3 - use the default parameter value in a Swagger

### DIFF
--- a/swagger-to-har.js
+++ b/swagger-to-har.js
@@ -170,8 +170,10 @@ var getQueryStrings = function (swagger, path, method, values) {
         queryStrings.push({
           name: param.name,
           value: typeof values[param.name] === 'undefined'
-            ? ('SOME_' + param.type.toUpperCase() + '_VALUE')
-            : values[param.name] + '' /* adding a empty string to convert to string */
+            ? (typeof param.default === 'undefined'
+              ? ('SOME_' + param.type.toUpperCase() + '_VALUE')
+              : param.default)
+            : (values[param.name] + '') /* adding a empty string to convert to string */
         })
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var SwaggerSnippet = require('../index')
 
 var InstagramSwagger = require('./instagram_swagger.json')
 var BloggerSwagger = require('./blogger_swagger.json')
+var GithubSwagger = require('./github_swagger.json')
 
 test('Getting snippets should not result in error or undefined', function (t) {
   t.plan(1)
@@ -49,4 +50,24 @@ test('Testing optionally provided parameter values', function (t) {
     })
   t.true(/5000/.test(result.snippets[0].content))
   t.false(/not-a-query-param/.test(result.snippets[0].content))
+})
+
+
+test('Testing the case when default is present but a value is provided, use the provided value', function (t) {
+  t.plan(2)
+  // checks the 'Pages' schema...
+  var result = SwaggerSnippet.getEndpointSnippets(GithubSwagger, '/issues', 'get', ['node_request'],
+    {
+      'filter': 'assigned'
+    })
+  t.true(/assigned/.test(result.snippets[0].content))
+  t.false(/all/.test(result.snippets[0].content)) // The default value of `filter` is `all`
+})
+
+test('Testing the case when default is present but no value is provided, use the default', function (t) {
+  t.plan(2)
+  // checks the 'Pages' schema...
+  var result = SwaggerSnippet.getEndpointSnippets(GithubSwagger, '/issues', 'get', ['node_request'])
+  t.false(/assigned/.test(result.snippets[0].content))
+  t.true(/all/.test(result.snippets[0].content))  // The default value of `filter` is `all`
 })


### PR DESCRIPTION
If a default value is provided and the client of swagger-snippet didn't provide a value, use the default value in the snippet.

If client code provides a value, even when a default value is present, the snippet should use the provided value.