### PR TITLE
Fix to handle relative '$ref' values.

### DIFF
--- a/swagger-to-har.js
+++ b/swagger-to-har.js
@@ -143,7 +143,7 @@ var getQueryStrings = function (swagger, path, method, values) {
     for (var i in swagger.paths[path][method].parameters) {
       var param = swagger.paths[path][method].parameters[i]
       if (typeof param['$ref'] === 'string' &&
-        !/^http/.test(param['$ref'])) {
+        /^#/.test(param['$ref'])) {
         param = resolveRef(swagger, param['$ref'])
       }
       if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'query') {


### PR DESCRIPTION
swagger-to-har.js: getQueryStrings() does not understand:

  $ref: '../relative-reference.json'

This patch changes the regular expression used within getQueryStrings() to
correctly recognize these references.